### PR TITLE
Transform elasticsearch errors with status 400 to flora RequestErrors…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 const logAdapter = require('./log-adapter');
 const createSearchConfig = require('./create-search-config');
+const { RequestError } = require('flora-errors');
 
 class DataSource {
     /**
@@ -53,7 +54,20 @@ class DataSource {
         }
 
         this.log.debug({ request, search }, 'flora-elasticsearch req -> search');
-        const response = (await this.client.search(search)).body;
+        let response = null;
+        try {
+            response = (await this.client.search(search)).body;
+        } catch (err) {
+            if (err && err.meta && err.meta.statusCode == 400) {
+                /* in order to at least expose some internal information from the elasticsearch error, extract the reason and error
+                name and re-throw it as a flora RequestError */
+                const elasticsearchErrorName = err.name || 'Unknown error';
+                const requestError = new RequestError(elasticsearchErrorName + ' from elasticsearch.');
+                requestError.info = { originalError: err };
+                throw requestError;
+            }
+            throw err;
+        }
 
         if (request._explain) {
             // eslint-disable-next-line require-atomic-updates

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "^7.10.0",
+    "flora-errors": "^2.0.0",
     "lodash": "^4.17.20"
   },
   "devDependencies": {


### PR DESCRIPTION
… so that APIs can respond with a proper status code to malformed queries