### PR TITLE
fix: ids filters must be intersected

### DIFF
--- a/lib/create-search-config.js
+++ b/lib/create-search-config.js
@@ -82,8 +82,9 @@ function combineFilters(conditions, attribute) {
     return conditions.reduce((result, { operator, value }) => {
         if (operator === 'equal') {
             if (attribute === '_id') {
+                const values = Array.isArray(value) ? value : [value];
                 result.ids = result.ids || {};
-                result.ids.values = [...(result.ids.values || []), ...(Array.isArray(value) ? value : [value])];
+                result.ids.values = intersect(values, result.ids.values || values);
                 return result;
             }
 
@@ -104,6 +105,11 @@ function combineFilters(conditions, attribute) {
 
         throw new ImplementationError(`Operator "${operator}" not implemented`);
     }, {});
+}
+
+function intersect(arrayA, arrayB) {
+    if (arrayA == arrayB) return arrayA; // shortcut for the same array
+    return arrayA.filter((value) => arrayB.includes(value));
 }
 
 function convertAndFilters(andFilters) {

--- a/test/create-search-config.spec.js
+++ b/test/create-search-config.spec.js
@@ -275,6 +275,34 @@ describe('create-search-config', () => {
                     }
                 });
             });
+
+            it('should correctly intersect ids filters', () => {
+                const { body } = createSearchConfig({
+                    ...floraRequest,
+                    filter: [
+                        [
+                            {
+                                attribute: '_id',
+                                operator: 'equal',
+                                valueFromSubFilter: 0,
+                                value: ['1', '2']
+                            },
+                            {
+                                attribute: '_id',
+                                operator: 'equal',
+                                value: '2'
+                            }
+                        ]
+                    ]
+                });
+
+                assert.ok(Object.hasOwn(body, 'query'));
+                assert.deepEqual(body.query, {
+                    ids: {
+                        values: ['2']
+                    }
+                });
+            });
         });
 
         Object.entries({


### PR DESCRIPTION
When combining multiple `ids` filters, we created a union of the ID sets, while the correct behavior is an intersection.